### PR TITLE
Support Numba 0.58

### DIFF
--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -25,8 +25,12 @@ except ImportError as ie:
 
 if _numba_version_ok:
     from numba.core import config
-    from numba.cuda.cudadrv.driver import (FILE_EXTENSION_MAP, NvrtcProgram,
-                                           Linker, LinkerError)
+    from numba.cuda.cudadrv.driver import (FILE_EXTENSION_MAP, Linker,
+                                           LinkerError)
+    if ver < (0, 58):
+        from numba.cuda.cudadrv.driver import NvrtcProgram
+    else:
+        from numba.cuda.cudadrv.nvrtc import NvrtcProgram
 else:
     # Prevent the definition of PatchedLinker failing if we have no Numba
     # Linker - it won't be used anyway.


### PR DESCRIPTION
The `NvrtcProgram` class moved to a new module, `numba.cuda.cudadrv.nvrtc` in Numba 0.58 (in PR numba/numba#9086), so we need to import it from there for that version onwards.