### PR TITLE
Disambiguate cuda major versions in wheel names

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,7 +7,7 @@ rapids-logger "Search artifact directory"
 ls ./artifact
 
 rapids-logger "Install wheel"
-pip install --find-links ./artifact pynvjitlink
+pip install --find-links ./artifact pynvjitlink-cu12
 
 rapids-logger "Build Tests"
 cd test_binary_generation && make

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "pynvjitlink"
+name = "pynvjitlink-cu12"
 version = "0.1.0"
 description = "nvJitLink Python binding"
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ cmake.minimum-version = "3.26.4"
 cmake.verbose = true
 ninja.make-fallback = true
 build-dir = "build/{wheel_tag}"
+wheel.packages = ["pynvjitlink"]
 
 [build-system]
 requires = ["scikit-build-core"]


### PR DESCRIPTION
This PR labels the wheel name with a `-cu12` suffix.