### PR TITLE
Separate pull request and tag workflows

### DIFF
--- a/.github/workflows/build_and_test_wheels.yaml
+++ b/.github/workflows/build_and_test_wheels.yaml
@@ -1,0 +1,91 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+jobs:
+  build-and-test-wheels:
+    needs:
+      - wheel-build-amd64
+      - wheel-build-arm64
+      - wheel-test-amd64
+      - wheel-test-arm64
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.12
+  wheel-build-amd64:
+    runs-on: linux-amd64-cpu4
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+    container:
+      image: "rapidsai/ci-wheel:cuda12.0.1-centos7-py${{ matrix.python-version }}"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Run build_wheel.sh
+      run: ci/build_wheel.sh
+    - name: Upload Python Wheel
+      uses: actions/upload-artifact@v3
+      with:
+        path: ./wheel-build
+  wheel-build-arm64:
+    runs-on: linux-arm64-cpu4
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+    container:
+      image: "rapidsai/ci-wheel:cuda12.0.1-rockylinux8-py${{ matrix.python-version }}"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Run build_wheel.sh
+      run: ci/build_wheel.sh
+    - name: Upload Python Wheel
+      uses: actions/upload-artifact@v3
+      with:
+        path: ./wheel-build
+  wheel-test-amd64:
+    needs:
+      - wheel-build-amd64
+    runs-on: linux-amd64-gpu-v100-latest-1
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+        linux-version: ["ubuntu20.04", "ubuntu18.04"]
+    container:
+      image: "rapidsai/citestwheel:cuda12.0.1-${{ matrix.linux-version }}-py${{ matrix.python-version }}"
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Download Python Wheel
+      uses: actions/download-artifact@v3
+      with:
+        path: ./
+    - name: Run test_wheel.sh
+      run: ci/test_wheel.sh
+  wheel-test-arm64:
+    needs:
+      - wheel-build-arm64
+    runs-on: linux-arm64-gpu-a100-latest-1
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+    container:
+      image: "rapidsai/citestwheel:cuda12.0.1-ubuntu20.04-py${{ matrix.python-version }}"
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Download Python Wheel
+      uses: actions/download-artifact@v3
+      with:
+        path: ./
+    - name: run test_wheel.sh
+      run: ci/test_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
-    tags:
-      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -16,10 +14,7 @@ jobs:
   pr-builder:
     needs:
       - checks
-      - wheel-build-amd64
-      - wheel-build-arm64
-      - wheel-test-amd64
-      - wheel-test-arm64
+      - build-and-test-wheels
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.12
   checks:
@@ -28,110 +23,5 @@ jobs:
     with:
       enable_check_generated_files: false
       enable_check_pr_job_dependencies: false
-  wheel-build-amd64:
-    runs-on: linux-amd64-cpu4
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
-    container:
-      image: "rapidsai/ci-wheel:cuda12.0.1-centos7-py${{ matrix.python-version }}"
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Get PR Info
-      id: get-pr-info
-      uses: rapidsai/shared-actions/get-pr-info@main
-    - name: Run build_wheel.sh
-      run: ci/build_wheel.sh
-    - name: Upload Python Wheel
-      uses: actions/upload-artifact@v3
-      with:
-        path: ./wheel-build
-  wheel-build-arm64:
-    runs-on: linux-arm64-cpu4
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
-    container:
-      image: "rapidsai/ci-wheel:cuda12.0.1-rockylinux8-py${{ matrix.python-version }}"
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Get PR Info
-      id: get-pr-info
-      uses: rapidsai/shared-actions/get-pr-info@main
-    - name: Run build_wheel.sh
-      run: ci/build_wheel.sh
-    - name: Upload Python Wheel
-      uses: actions/upload-artifact@v3
-      with:
-        path: ./wheel-build
-  wheel-test-amd64:
-    needs:
-      - wheel-build-amd64
-    runs-on: linux-amd64-gpu-v100-latest-1
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
-        linux-version: ["ubuntu20.04", "ubuntu18.04"]
-    container:
-      image: "rapidsai/citestwheel:cuda12.0.1-${{ matrix.linux-version }}-py${{ matrix.python-version }}"
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Get PR Info
-      id: get-pr-info
-      uses: rapidsai/shared-actions/get-pr-info@main
-    - name: Download Python Wheel
-      uses: actions/download-artifact@v3
-      with:
-        path: ./
-    - name: Run test_wheel.sh
-      run: ci/test_wheel.sh
-  wheel-test-arm64:
-    needs:
-      - wheel-build-arm64
-    runs-on: linux-arm64-gpu-a100-latest-1
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
-    container:
-      image: "rapidsai/citestwheel:cuda12.0.1-ubuntu20.04-py${{ matrix.python-version }}"
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Get PR Info
-      id: get-pr-info
-      uses: rapidsai/shared-actions/get-pr-info@main
-    - name: Download Python Wheel
-      uses: actions/download-artifact@v3
-      with:
-        path: ./
-    - name: run test_wheel.sh
-      run: ci/test_wheel.sh
-  wheel-publish-pynvjitlink:
-    needs:
-      - wheel-test-amd64
-      - wheel-test-arm64
-    # Only trigger this step for tags
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-23.12
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: pynvjitlink
+  build-and-test-wheels:
+    uses: ./build_and_test_wheels.yaml


### PR DESCRIPTION
This PR implements a two-workflow approach where one workflow is responsible for pull requests and another is responsible for tags and uploading wheels. 