### PR TITLE
Add a `wheels-publish` job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -28,3 +30,14 @@ jobs:
       build_type: branch
       script: "ci/build_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.BUILD_MATRIX }}
+  publish-wheels:
+    needs:
+      - build-wheels
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: pynvjitlink-cu12

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,4 +40,4 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
-      package-name: pynvjitlink-cu12
+      package-name: pynvjitlink

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,5 +36,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
     with:
-      build_type: pull-request
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
       package-name: pynvjitlink

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,5 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
+      build_type: pull-request
       package-name: pynvjitlink

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ jobs:
       - compute-matrix
       - build-wheels
       - test-wheels
+      - publish-wheels
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02
   checks:
@@ -51,3 +52,14 @@ jobs:
       build_type: pull-request
       script: "ci/test_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
+  publish-wheels:
+    needs:
+      - build-wheels
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: pynvjitlink-cu12

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,11 +52,3 @@ jobs:
       build_type: pull-request
       script: "ci/test_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
-  publish-wheels:
-    needs:
-      - build-wheels
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
-    with:
-      build_type: pull-request
-      package-name: pynvjitlink

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,4 +62,4 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
-      package-name: pynvjitlink-cu12
+      package-name: pynvjitlink

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,6 @@ jobs:
       - compute-matrix
       - build-wheels
       - test-wheels
-      - publish-wheels
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02
   checks:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,8 +58,5 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: pynvjitlink
+      build_type: pull-request
+      package-name: pynvjitlink-cu12

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,4 +59,4 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.02
     with:
       build_type: pull-request
-      package-name: pynvjitlink-cu12
+      package-name: pynvjitlink

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -16,4 +16,4 @@ mkdir -p ./wheel-build
 pip wheel . --wheel-dir=./wheel-build -vvv
 
 rapids-logger "Upload Wheel"
-rapids-upload-wheels-to-s3 ./wheel-build
+RAPIDS_PY_WHEEL_NAME="pynvjitlink-cu12" rapids-upload-wheels-to-s3 ./wheel-build

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,7 +4,7 @@
 set -e
 
 rapids-logger "Download Wheel"
-rapids-download-wheels-from-s3 ./wheel-build/
+RAPIDS_PY_WHEEL_NAME="pynvjitlink-cu12" rapids-download-wheels-from-s3 ./wheel-build/
 
 rapids-logger "Install wheel"
 pip install --find-links ./wheel-build pynvjitlink-cu12


### PR DESCRIPTION
This PR adds a job to our release workflow which uploads release wheels to the nightly rapids pypi index.