### PR TITLE
Don't upload wheels when merging to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ name: build
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
This PR changes the release workflow to only upload wheels when a tag is pushed. 