### PR TITLE
[REVIEW] remove references to setup.py in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ work-in-progress.
 TODO
 
 ## Install pynvjitlink
+
 Install with either:
 
-```
-python setup.py develop
+```shell
+python -m pip install -e .
 ```
 
 or
 
-```
-python setup.py install
+```shell
+python -m pip install .
 ```
 
 ### Conda


### PR DESCRIPTION
Proposes removing references to `setup.py` in this project's docs. This project doesn't use a `setup.py` file.

### How I tested this

On a machine with a couple V100s, ran the following (based on what I see in this project's CI):

```shell
docker run \
    --rm \
    --gpus all \
    -v $(pwd):/usr/local/pynvjitlink \
    -w /usr/local/pynvjitlink \
    -it rapidsai/ci-wheel:cuda12.0.1-centos7-py3.9 \
    bash

# installed CTK following this:
# https://github.com/rapidsai/pynvjitlink/blob/56a6d74f365c3e601a503dfd6a58ad4e3fc532c7/ci/build_wheel.sh
yum update -y
yum install -y \
    cuda-toolkit-12-3 \
    epel-release \
    nvidia-driver-latest-dkms

# skipped using sccache, just to avoid having to set up credentials
unset \
    CMAKE_C_COMPILER_LAUNCHER \
    CMAKE_CUDA_COMPILER_LAUNCHER \
    CMAKE_CXX_COMPILER_LAUNCHER

# built a wheel and installed it
python -m pip install -e .

# tested
make -C ./test_binary_generation
pip install pytest
pytest -v ./pynvjitlink/tests
```

I saw that build succeed and all tests pass.

### Notes for Reviewers

In case you're wondering "what is this random contribution"... I recently joined NVIDIA and am working on RAPIDS packaging stuff. Was just poking around this repo and noticed in this in the README.

Thanks for your time and consideration.