### PR TITLE
Set `build-conda`'s `build_type` to `branch`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - compute-matrix
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.02
     with:
-      build_type: pull-request
+      build_type: branch
       build_script: "ci/build_conda.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.BUILD_MATRIX }}
   publish-wheels:


### PR DESCRIPTION
PRs are handled in...

https://github.com/rapidsai/pynvjitlink/blob/9765e2ba77f99a3d6e30ca6ab744e01faaeb0e7e/.github/workflows/pr.yaml#L2

Whereas tags are handled in...

https://github.com/rapidsai/pynvjitlink/blob/9765e2ba77f99a3d6e30ca6ab744e01faaeb0e7e/.github/workflows/build.yaml#L2

That said, `build-conda`'s was configured as if it built for PRs

https://github.com/rapidsai/pynvjitlink/blob/9765e2ba77f99a3d6e30ca6ab744e01faaeb0e7e/.github/workflows/build.yaml#L36

This differs from how `build-wheels` was configured to build for branches

https://github.com/rapidsai/pynvjitlink/blob/9765e2ba77f99a3d6e30ca6ab744e01faaeb0e7e/.github/workflows/build.yaml#L28

So this PR aligns the Conda builds to match the wheel builds in terms of `build_type`

Think this may have affected Conda package uploads ( https://github.com/rapidsai/pynvjitlink/pull/42#issuecomment-1890230691 ) as packages were not where the upload job expected to find them. Placing them in the right location should fix this issue