### PR TITLE
Relax `cuda-version` constraint

### DIFF
--- a/conda/recipes/pynvjitlink/meta.yaml
+++ b/conda/recipes/pynvjitlink/meta.yaml
@@ -23,6 +23,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv
   ignore_run_exports_from:
+    - {{ compiler('cuda') }}
     - libnvjitlink-dev
 
 requirements:


### PR DESCRIPTION
When using `{{ compiler('cuda') }}`, it adds a `cuda-version` constraint lower bound based on the version it built with to the package. However this conflicts with the intended usage of this package and the `cuda-version` constraint this package adds itself. So ignore the constraint added by `{{ compiler('cuda') }}`.