### PR TITLE
Update Conda to CUDA 12.3

### DIFF
--- a/conda/recipes/pynvjitlink/conda_build_config.yaml
+++ b/conda/recipes/pynvjitlink/conda_build_config.yaml
@@ -8,4 +8,4 @@ cuda_compiler:
   - cuda-nvcc
 
 cuda_compiler_version:
-  - 12.2
+  - 12.3

--- a/pynvjitlink/tests/test_pynvjitlink_api.py
+++ b/pynvjitlink/tests/test_pynvjitlink_api.py
@@ -94,11 +94,6 @@ def test_add_cubin_with_fatbin_error(device_functions_fatbin):
         nvjitlinker.add_cubin(device_functions_fatbin, name)
 
 
-@pytest.mark.xfail(
-    reason="Fails in conda due to using CUDA 12.2u2. This should be fixed "
-    "when requiring CUDA 12.3 nvjitlink library. See: "
-    "https://github.com/rapidsai/pynvjitlink/pull/33#issuecomment-1885182905"
-)
 def test_add_fatbin_with_cubin_error(device_functions_cubin):
     nvjitlinker = NvJitLinker("-arch=sm_75")
     name = "test_device_functions.cubin"


### PR DESCRIPTION
Now that CUDA 12.3 is available in conda-forge ( https://github.com/conda-forge/cuda-feedstock/issues/15 ), update the Conda builds here to use CUDA 12.3.

Fixes https://github.com/rapidsai/pynvjitlink/pull/51