### PR TITLE
Use add_library to link archives in Numba patch

### DIFF
--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -104,7 +104,7 @@ class PatchedLinker(Linker):
         elif kind == FILE_EXTENSION_MAP["fatbin"]:
             fn = self._linker.add_fatbin
         elif kind == FILE_EXTENSION_MAP["a"]:
-            raise LinkerError("Don't know how to link archives")
+            fn = self._linker.add_library
         elif kind == FILE_EXTENSION_MAP["ptx"]:
             return self.add_ptx(data, name)
         elif kind == FILE_EXTENSION_MAP["o"]:


### PR DESCRIPTION
The required functionality has been available in the underlying API, and just not called by the patch. This enables linking of archives by the patched linker, and therefore fixes the issues with cooperative groups in Numba.

Fixes #53 