### PR TITLE
Test with cuda-cudart-static libraries for cooperative group support

### DIFF
--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 rapids-logger "Generate testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 rapids-mamba-retry create -n test \
-    cuda-nvcc-impl \
+    cuda-nvcc \
     cuda-nvrtc \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \


### PR DESCRIPTION
In https://github.com/rapidsai/pynvjitlink/issues/53#issuecomment-1942948977, @gmarkall noticed that some Numba tests for cooperative groups were being skipped. They show a skip reason of `cudadevrt missing`. I traced [this Numba test skipping code](https://github.com/numba/numba/blob/3edb458c69daeaaffbfc938145c367eda1cf043f/numba/cuda/testing.py#L170-L182) and the dependency list in `test_patch.sh`, and found that `libcudadevrt.a` was probably not available in the CI environment.

This PR switches from `cuda-nvcc-impl` to `cuda-nvcc` in the CI environment, which includes the missing `libcudadevrt.a`. In particular, this will ensure we get `cuda-cudart-static` packages in the testing environment.

We can verify this PR by ensuring that the following tests are run (and not skipped):
```
test_cache_cg (numba.cuda.tests.cudapy.test_caching.CUDACachingTest.test_cache_cg) ... skipped 'cudadevrt missing'
...
test_false_cooperative_doesnt_link_cudadevrt (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_false_cooperative_doesnt_link_cudadevrt)
We should only mark a kernel as cooperative and link cudadevrt if the ... skipped 'cudadevrt missing'
test_max_cooperative_grid_blocks (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_max_cooperative_grid_blocks) ... skipped 'cudadevrt missing'
test_sync_at_matrix_row (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_sync_at_matrix_row) ... skipped 'cudadevrt missing'
test_sync_group (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_sync_group) ... skipped 'cudadevrt missing'
test_sync_group_is_cooperative (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_sync_group_is_cooperative) ... skipped 'cudadevrt missing'
test_this_grid (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_this_grid) ... skipped 'cudadevrt missing'
test_this_grid_is_cooperative (numba.cuda.tests.cudapy.test_cooperative_groups.TestCudaCooperativeGroups.test_this_grid_is_cooperative) ... skipped 'cudadevrt missing'
...
test_ex_grid_sync (numba.cuda.tests.doc_examples.test_cg.TestCooperativeGroups.test_ex_grid_sync) ... skipped 'cudadevrt missing'
```