### PR TITLE
Install missing test deps & align testing protocols across formats

### DIFF
--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -41,6 +41,9 @@ popd
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+rapids-logger "Show Numba system info"
+python -m numba --sysinfo
+
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -45,11 +45,12 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
-rapids-logger "pytest pynvjitlink"
+rapids-logger "Run Tests"
 python -m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-pynvjitlink.xml" \
-  -v
+  -v \
+  pynvjitlink/tests
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -11,6 +11,7 @@ rapids-mamba-retry create -n test \
     c-compiler \
     cxx-compiler \
     cuda-nvcc \
+    cuda-nvrtc \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \
     make \

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -46,11 +46,12 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "Run Tests"
+pushd pynvjitlink/tests
 python -m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-pynvjitlink.xml" \
-  -v \
-  pynvjitlink/tests
+  -v
+popd
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -45,7 +45,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest pynvjitlink"
-pytest \
+python -m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-pynvjitlink.xml" \
   -v

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -15,6 +15,7 @@ rapids-mamba-retry create -n test \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \
     make \
+    psutil \
     pytest \
     python=${RAPIDS_PY_VERSION}
 

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
-rapids-logger "Generate testing dependencies"
+rapids-logger "Install testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 rapids-mamba-retry create -n test \
     c-compiler \

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
-rapids-logger "Generate testing dependencies"
+rapids-logger "Install testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 rapids-mamba-retry create -n test \
     cuda-nvcc-impl \

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 rapids-logger "Install testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 rapids-mamba-retry create -n test \
-    cuda-nvcc-impl \
+    cuda-nvcc \
     cuda-nvrtc \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -12,6 +12,7 @@ rapids-mamba-retry create -n test \
     cuda-nvrtc \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \
+    psutil \
     python=${RAPIDS_PY_VERSION}
 
 # Temporarily allow unbound variables for conda activation.

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -30,6 +30,9 @@ rapids-mamba-retry install \
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+rapids-logger "Show Numba system info"
+python -m numba --sysinfo
+
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -26,4 +26,8 @@ make
 popd
 
 rapids-logger "Run Tests"
-python -m pytest pynvjitlink/tests
+python -m pytest \
+  --cache-clear \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-pynvjitlink.xml" \
+  -v \
+  pynvjitlink/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+rapids-logger "Install testing dependencies"
+# TODO: Replace with rapids-dependency-file-generator
+python -m pip install \
+    "numba>=0.58" \
+    pytest
+
 rapids-logger "Download Wheel"
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist/
@@ -20,5 +26,4 @@ make
 popd
 
 rapids-logger "Run Tests"
-python -m pip install pytest
 python -m pytest pynvjitlink/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -31,6 +31,9 @@ popd
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+rapids-logger "Show Numba system info"
+python -m numba --sysinfo
+
 rapids-logger "Run Tests"
 pushd pynvjitlink/tests
 python -m pytest \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -17,6 +17,9 @@ RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-whee
 # everywhere except in the final wheel name.
 PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
 
+RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
+mkdir -p "${RAPIDS_TESTS_DIR}"
+
 rapids-logger "Install wheel"
 python -m pip install --find-links ./dist pynvjitlink${PACKAGE_CUDA_SUFFIX}
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -26,8 +26,9 @@ make
 popd
 
 rapids-logger "Run Tests"
+pushd pynvjitlink/tests
 python -m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-pynvjitlink.xml" \
-  -v \
-  pynvjitlink/tests
+  -v
+popd

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,6 +7,7 @@ rapids-logger "Install testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 python -m pip install \
     "numba>=0.58" \
+    psutil \
     pytest
 
 rapids-logger "Download Wheel"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -12,7 +12,7 @@ RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-whee
 PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
 
 rapids-logger "Install wheel"
-pip install --find-links ./dist pynvjitlink${PACKAGE_CUDA_SUFFIX}
+python -m pip install --find-links ./dist pynvjitlink${PACKAGE_CUDA_SUFFIX}
 
 rapids-logger "Build Tests"
 pushd test_binary_generation
@@ -20,5 +20,5 @@ make
 popd
 
 rapids-logger "Run Tests"
-pip install pytest
-pytest pynvjitlink/tests
+python -m pip install pytest
+python -m pytest pynvjitlink/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -28,6 +28,9 @@ pushd test_binary_generation
 make
 popd
 
+rapids-logger "Check GPU usage"
+nvidia-smi
+
 rapids-logger "Run Tests"
 pushd pynvjitlink/tests
 python -m pytest \


### PR DESCRIPTION
Install a few things that were needed

* `cuda-nvrtc` for Conda tests
* Use `cuda-nvcc` in all cases
* Wheel dependencies at start (`numba` was missed; `pytest` was done later)
* Also run with `python -m <...>` to ensure the same `python` is used for installs & tests
* Run `nvidia-smi` in all tests (missing in some places)
* Run `python -m numba --sysinfo` in all tests (gets info about Numba's config and what Numba is missing)
* Install `psutil` for more Numba config info
* Generally align testing across package formats

Fixes https://github.com/rapidsai/pynvjitlink/pull/55