### PR TITLE
Update to CUDA 12.4

### DIFF
--- a/ci/install_latest_cuda_toolkit.sh
+++ b/ci/install_latest_cuda_toolkit.sh
@@ -17,4 +17,4 @@ else
     exit 1
 fi
 
-yum install -y cuda-toolkit-12-3
+yum install -y cuda-toolkit-12-4

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -14,15 +14,11 @@ rapids-logger "Download Wheel"
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist/
 
-# This is the version of the suffix with a preceding hyphen. It's used
-# everywhere except in the final wheel name.
-PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
-
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 rapids-logger "Install wheel"
-python -m pip install $(echo ./dist/pynvjitlink*.whl)
+python -m pip install $(echo ./dist/pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}*.whl)
 
 rapids-logger "Build Tests"
 pushd test_binary_generation

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -22,7 +22,7 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 rapids-logger "Install wheel"
-python -m pip install --find-links ./dist pynvjitlink${PACKAGE_CUDA_SUFFIX}
+python -m pip install $(echo ./dist/pynvjitlink*.whl)
 
 rapids-logger "Build Tests"
 pushd test_binary_generation

--- a/conda/recipes/pynvjitlink/conda_build_config.yaml
+++ b/conda/recipes/pynvjitlink/conda_build_config.yaml
@@ -8,4 +8,4 @@ cuda_compiler:
   - cuda-nvcc
 
 cuda_compiler_version:
-  - 12.3
+  - 12.4


### PR DESCRIPTION
This PR updates pynvjitlink to use CUDA 12.4. This depends on https://github.com/conda-forge/libnvjitlink-feedstock/pull/9.