### PR TITLE
Drop version hard-coding from YCM conf

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 CONDA_PREFIX = os.environ["CONDA_PREFIX"]
 NVJITLINK_DIR = Path(__file__).parent
-VER = sys.version_info
-PYTHON_INCLUDE_NAME = "python3.10"  # Not ideal
+PYTHON_VERSION = sys.version_info
+PYTHON_INCLUDE_NAME = "python%d.%d" % PYTHON_VERSION
 
 CONDA_INCLUDE_DIR = Path(CONDA_PREFIX, "include")
 PYTHON_INCLUDE_DIR = Path(CONDA_INCLUDE_DIR, PYTHON_INCLUDE_NAME)
 NVJITLINK_INCLUDE_DIR = Path(NVJITLINK_DIR, "include")
-CUDA_INCLUDE_DIR = "/usr/local/cuda-12.0/include"
+CUDA_INCLUDE_DIR = "/usr/local/cuda/include"
 
 flags = [
     "--cuda-gpu-arch=sm_50",


### PR DESCRIPTION
Fixes https://github.com/rapidsai/pynvjitlink/issues/63

* Dynamically determine the Python version
* Use `/usr/local/cuda` as this often points to the latest version