### PR TITLE
Fix `__version__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,7 +9,11 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.3.7
     hooks:
       - id: ruff
       - id: ruff-format
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v0.0.3
+    hooks:
+      - id: verify-copyright

--- a/pynvjitlink/__init__.py
+++ b/pynvjitlink/__init__.py
@@ -1,6 +1,6 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 from pynvjitlink.api import NvJitLinker, NvJitLinkError
+from pynvjitlink._version import __version__
 
-__all__ = (NvJitLinker, NvJitLinkError)
-__version__ = "0.0.0"
+__all__ = [NvJitLinker, NvJitLinkError, __version__]

--- a/pynvjitlink/_version.py
+++ b/pynvjitlink/_version.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.resources
+
+__version__ = (
+    importlib.resources.files("pynvjitlink").joinpath("VERSION").read_text().strip()
+)

--- a/pynvjitlink/tests/test_pynvjitlink.py
+++ b/pynvjitlink/tests/test_pynvjitlink.py
@@ -1,8 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
 
 import os
 import pytest
 
+import pynvjitlink
 from pynvjitlink import _nvjitlinklib
 from pynvjitlink.api import InputType
 
@@ -203,3 +204,8 @@ def test_get_linked_ptx_link_not_complete_error(device_functions_ltoir, gpu_arch
     with pytest.raises(RuntimeError, match="NVJITLINK_ERROR_INTERNAL error"):
         _nvjitlinklib.get_linked_ptx(handle)
     _nvjitlinklib.destroy(handle)
+
+
+def test_package_version():
+    assert pynvjitlink.__version__ is not None
+    assert len(str(pynvjitlink.__version__)) > 0


### PR DESCRIPTION
This PR fixes the `pynvjitlink.__version__` attribute to read from the `VERSION` file.

Fixes https://github.com/rapidsai/pynvjitlink/issues/70