### PR TITLE
Numba patch: Enable LTOIR to be linked from memory instead of files

### DIFF
--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -98,6 +98,13 @@ class Object(LinkableCode):
     default_name = "<unnamed-object>"
 
 
+class LTOIR(LinkableCode):
+    """An LTOIR file in memory"""
+
+    kind = "ltoir"
+    default_name = "<unnamed-ltoir>"
+
+
 class PatchedLinker(Linker):
     def __init__(
         self,
@@ -259,3 +266,4 @@ def patch_numba_linker():
     cuda.Fatbin = Fatbin
     cuda.Object = Object
     cuda.PTXSource = PTXSource
+    cuda.LTOIR = LTOIR

--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 from pynvjitlink.api import NvJitLinker, NvJitLinkError
 
 import os

--- a/pynvjitlink/tests/conftest.py
+++ b/pynvjitlink/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from numba import cuda
-from pynvjitlink.patch import Archive, Cubin, CUSource, Fatbin, Object, PTXSource, LTOIR
+from pynvjitlink.patch import Archive, Cubin, CUSource, Fatbin, Object, PTXSource
 
 
 @pytest.fixture(scope="session")
@@ -114,14 +114,6 @@ def undefined_extern_cubin():
 
 
 @pytest.fixture(scope="session")
-def device_functions_ltoir():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.ltoir")
-    with open(path, "rb") as f:
-        return f.read()
-
-
-@pytest.fixture(scope="session")
 def linkable_code_archive(device_functions_archive):
     return Archive(device_functions_archive)
 
@@ -149,8 +141,3 @@ def linkable_code_object(device_functions_object):
 @pytest.fixture(scope="session")
 def linkable_code_ptx(device_functions_ptx):
     return PTXSource(device_functions_ptx)
-
-
-@pytest.fixture(scope="session")
-def linkable_code_ltoir(device_functions_ltoir):
-    return LTOIR(device_functions_ltoir)

--- a/pynvjitlink/tests/conftest.py
+++ b/pynvjitlink/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from numba import cuda
-from pynvjitlink.patch import Archive, Cubin, CUSource, Fatbin, Object, PTXSource
+from pynvjitlink.patch import Archive, Cubin, CUSource, Fatbin, Object, PTXSource, LTOIR
 
 
 @pytest.fixture(scope="session")
@@ -114,6 +114,14 @@ def undefined_extern_cubin():
 
 
 @pytest.fixture(scope="session")
+def device_functions_ltoir():
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(test_dir, "test_device_functions.ltoir")
+    with open(path, "rb") as f:
+        return f.read()
+
+
+@pytest.fixture(scope="session")
 def linkable_code_archive(device_functions_archive):
     return Archive(device_functions_archive)
 
@@ -141,3 +149,8 @@ def linkable_code_object(device_functions_object):
 @pytest.fixture(scope="session")
 def linkable_code_ptx(device_functions_ptx):
     return PTXSource(device_functions_ptx)
+
+
+@pytest.fixture(scope="session")
+def linkable_code_ltoir(device_functions_ltoir):
+    return LTOIR(device_functions_ltoir)

--- a/pynvjitlink/tests/test_patch.py
+++ b/pynvjitlink/tests/test_patch.py
@@ -133,7 +133,12 @@ def test_add_file_guess_ext_invalid_input(
         "linkable_code_fatbin",
         "linkable_code_object",
         "linkable_code_ptx",
-        "linkable_code_ltoir",
+        pytest.param(
+            "linkable_code_ltoir",
+            marks=pytest.mark.xfail(
+                reason=".ltoir file is actually an object and lto=True missing"
+            ),
+        ),
     ),
 )
 def test_jit_with_linkable_code(file, request):

--- a/pynvjitlink/tests/test_patch.py
+++ b/pynvjitlink/tests/test_patch.py
@@ -133,6 +133,7 @@ def test_add_file_guess_ext_invalid_input(
         "linkable_code_fatbin",
         "linkable_code_object",
         "linkable_code_ptx",
+        "linkable_code_ltoir",
     ),
 )
 def test_jit_with_linkable_code(file, request):

--- a/pynvjitlink/tests/test_patch.py
+++ b/pynvjitlink/tests/test_patch.py
@@ -133,7 +133,6 @@ def test_add_file_guess_ext_invalid_input(
         "linkable_code_fatbin",
         "linkable_code_object",
         "linkable_code_ptx",
-        "linkable_code_ltoir",
     ),
 )
 def test_jit_with_linkable_code(file, request):


### PR DESCRIPTION
This PR adds support for linking LTO-IR code from memory in the Numba monkey patch.

This is done by creating a new class `LTOIR` with `kind = 'ltoir'`. 
Passing an instance of `LTOIR` to `numba.cuda.jit(link=...)` will enable linking directly from memory, bypassing the need to write the file to disk with an `.ltoir` extension.

cc @gmarkall @leofang 