### PR TITLE
Enable patching linker for LTO, and test LTO-IR linkable code

### DIFF
--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -12,6 +12,7 @@ rapids-mamba-retry create -n test \
     cxx-compiler \
     cuda-nvcc \
     cuda-nvrtc \
+    cuda-python \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \
     make \

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -10,6 +10,7 @@ rapids-logger "Install testing dependencies"
 rapids-mamba-retry create -n test \
     cuda-nvcc \
     cuda-nvrtc \
+    cuda-python \
     cuda-version=${RAPIDS_CUDA_VERSION%.*} \
     "numba>=0.58" \
     psutil \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,6 +8,7 @@ rapids-logger "Install testing dependencies"
 python -m pip install \
     "numba>=0.58" \
     psutil \
+    cuda-python \
     pytest
 
 rapids-logger "Download Wheel"

--- a/pynvjitlink/tests/conftest.py
+++ b/pynvjitlink/tests/conftest.py
@@ -85,6 +85,11 @@ def device_functions_ltoir():
 
 
 @pytest.fixture(scope="session")
+def device_functions_ltoir_object():
+    return read_test_file("test_device_functions.ltoir.o")
+
+
+@pytest.fixture(scope="session")
 def device_functions_object():
     return read_test_file("test_device_functions.o")
 

--- a/pynvjitlink/tests/conftest.py
+++ b/pynvjitlink/tests/conftest.py
@@ -57,100 +57,90 @@ def absent_gpu_arch_flag(absent_gpu_compute_capability):
     return f"-arch=sm_{major}{minor}"
 
 
-@pytest.fixture(scope="session")
-def device_functions_archive():
+def read_test_file(filename):
     test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.a")
+    path = os.path.join(test_dir, filename)
     with open(path, "rb") as f:
-        return f.read()
-
-
-@pytest.fixture(scope="session")
-def device_functions_cubin():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.cubin")
-    with open(path, "rb") as f:
-        return f.read()
+        return filename, f.read()
 
 
 @pytest.fixture(scope="session")
 def device_functions_cusource():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.cu")
-    with open(path, "r") as f:
-        return f.read()
+    return read_test_file("test_device_functions.cu")
+
+
+@pytest.fixture(scope="session")
+def device_functions_cubin():
+    return read_test_file("test_device_functions.cubin")
 
 
 @pytest.fixture(scope="session")
 def device_functions_fatbin():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.fatbin")
-    with open(path, "rb") as f:
-        return f.read()
-
-
-@pytest.fixture(scope="session")
-def device_functions_object():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.o")
-    with open(path, "rb") as f:
-        return f.read()
-
-
-@pytest.fixture(scope="session")
-def device_functions_ptx():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.ptx")
-    with open(path, "rb") as f:
-        return f.read()
-
-
-@pytest.fixture(scope="session")
-def undefined_extern_cubin():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    fatbin_path = os.path.join(test_dir, "undefined_extern.cubin")
-    with open(fatbin_path, "rb") as f:
-        return f.read()
+    return read_test_file("test_device_functions.fatbin")
 
 
 @pytest.fixture(scope="session")
 def device_functions_ltoir():
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, "test_device_functions.ltoir")
-    with open(path, "rb") as f:
-        return f.read()
+    return read_test_file("test_device_functions.ltoir")
+
+
+@pytest.fixture(scope="session")
+def device_functions_object():
+    return read_test_file("test_device_functions.o")
+
+
+@pytest.fixture(scope="session")
+def device_functions_archive():
+    return read_test_file("test_device_functions.a")
+
+
+@pytest.fixture(scope="session")
+def device_functions_ptx():
+    return read_test_file("test_device_functions.ptx")
+
+
+@pytest.fixture(scope="session")
+def undefined_extern_cubin():
+    return read_test_file("undefined_extern.cubin")
 
 
 @pytest.fixture(scope="session")
 def linkable_code_archive(device_functions_archive):
-    return Archive(device_functions_archive)
+    name, data = device_functions_archive
+    return Archive(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_cubin(device_functions_cubin):
-    return Cubin(device_functions_cubin)
+    name, data = device_functions_cubin
+    return Cubin(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_cusource(device_functions_cusource):
-    return CUSource(device_functions_cusource)
+    name, data = device_functions_cusource
+    return CUSource(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_fatbin(device_functions_fatbin):
-    return Fatbin(device_functions_fatbin)
+    name, data = device_functions_fatbin
+    return Fatbin(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_object(device_functions_object):
-    return Object(device_functions_object)
+    name, data = device_functions_object
+    return Object(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_ptx(device_functions_ptx):
-    return PTXSource(device_functions_ptx)
+    name, data = device_functions_ptx
+    return PTXSource(data, name=name)
 
 
 @pytest.fixture(scope="session")
 def linkable_code_ltoir(device_functions_ltoir):
-    return LTOIR(device_functions_ltoir)
+    name, data = device_functions_ltoir
+    return LTOIR(data, name=name)

--- a/pynvjitlink/tests/test_pynvjitlink.py
+++ b/pynvjitlink/tests/test_pynvjitlink.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
 
-import os
 import pytest
 
 import pynvjitlink
@@ -154,7 +153,9 @@ def test_get_linked_ptx_from_lto(device_functions_ltoir_object, gpu_arch_flag):
     _nvjitlinklib.destroy(handle)
 
 
-def test_get_linked_ptx_link_not_complete_error(device_functions_ltoir_object, gpu_arch_flag):
+def test_get_linked_ptx_link_not_complete_error(
+    device_functions_ltoir_object, gpu_arch_flag
+):
     handle = _nvjitlinklib.create(gpu_arch_flag, "-lto", "-ptx")
     filename, data = device_functions_ltoir_object
     input_type = InputType.OBJECT.value

--- a/pynvjitlink/tests/test_pynvjitlink.py
+++ b/pynvjitlink/tests/test_pynvjitlink.py
@@ -8,48 +8,6 @@ from pynvjitlink import _nvjitlinklib
 from pynvjitlink.api import InputType
 
 
-def read_test_file(filename):
-    test_dir = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(test_dir, filename)
-    with open(path, "rb") as f:
-        return filename, f.read()
-
-
-@pytest.fixture
-def device_functions_cubin():
-    return read_test_file("test_device_functions.cubin")
-
-
-@pytest.fixture
-def device_functions_fatbin():
-    return read_test_file("test_device_functions.fatbin")
-
-
-@pytest.fixture
-def device_functions_ltoir():
-    return read_test_file("test_device_functions.ltoir")
-
-
-@pytest.fixture
-def device_functions_object():
-    return read_test_file("test_device_functions.o")
-
-
-@pytest.fixture
-def device_functions_archive():
-    return read_test_file("test_device_functions.a")
-
-
-@pytest.fixture
-def device_functions_ptx():
-    return read_test_file("test_device_functions.ptx")
-
-
-@pytest.fixture
-def undefined_extern_cubin():
-    return read_test_file("undefined_extern.cubin")
-
-
 def test_create_no_arch_error():
     # nvjitlink expects at least the architecture to be specified.
     with pytest.raises(RuntimeError, match="NVJITLINK_ERROR_MISSING_ARCH error"):

--- a/pynvjitlink/tests/test_pynvjitlink.py
+++ b/pynvjitlink/tests/test_pynvjitlink.py
@@ -63,8 +63,8 @@ def test_add_file(input_file, input_type, gpu_arch_flag, request):
 # We test the LTO input case separately as it requires the `-lto` flag. The
 # OBJECT input type is used because the LTO-IR container is packaged in an ELF
 # object when produced by NVCC.
-def test_add_file_lto(device_functions_ltoir, gpu_arch_flag):
-    filename, data = device_functions_ltoir
+def test_add_file_lto(device_functions_ltoir_object, gpu_arch_flag):
+    filename, data = device_functions_ltoir_object
 
     handle = _nvjitlinklib.create(gpu_arch_flag, "-lto")
     _nvjitlinklib.add_data(handle, InputType.OBJECT.value, data, filename)
@@ -123,11 +123,11 @@ def test_get_linked_cubin_link_not_complete_error(
     _nvjitlinklib.destroy(handle)
 
 
-def test_get_linked_cubin_from_lto(device_functions_ltoir, gpu_arch_flag):
-    filename, data = device_functions_ltoir
-    # device_functions_ltoir is a host object containing a fatbin containing an
-    # LTOIR container, because that is what NVCC produces when LTO is
-    # requested. So we need to use the OBJECT input type, and the linker
+def test_get_linked_cubin_from_lto(device_functions_ltoir_object, gpu_arch_flag):
+    filename, data = device_functions_ltoir_object
+    # device_functions_ltoir_object is a host object containing a fatbin
+    # containing an LTOIR container, because that is what NVCC produces when
+    # LTO is requested. So we need to use the OBJECT input type, and the linker
     # retrieves the LTO IR from it because we passed the -lto flag.
     input_type = InputType.OBJECT.value
     handle = _nvjitlinklib.create(gpu_arch_flag, "-lto")
@@ -140,11 +140,11 @@ def test_get_linked_cubin_from_lto(device_functions_ltoir, gpu_arch_flag):
     assert cubin[:4] == b"\x7fELF"
 
 
-def test_get_linked_ptx_from_lto(device_functions_ltoir, gpu_arch_flag):
-    filename, data = device_functions_ltoir
-    # device_functions_ltoir is a host object containing a fatbin containing an
-    # LTOIR container, because that is what NVCC produces when LTO is
-    # requested. So we need to use the OBJECT input type, and the linker
+def test_get_linked_ptx_from_lto(device_functions_ltoir_object, gpu_arch_flag):
+    filename, data = device_functions_ltoir_object
+    # device_functions_ltoir_object is a host object containing a fatbin
+    # containing an LTOIR container, because that is what NVCC produces when
+    # LTO is requested. So we need to use the OBJECT input type, and the linker
     # retrieves the LTO IR from it because we passed the -lto flag.
     input_type = InputType.OBJECT.value
     handle = _nvjitlinklib.create(gpu_arch_flag, "-lto", "-ptx")
@@ -154,9 +154,9 @@ def test_get_linked_ptx_from_lto(device_functions_ltoir, gpu_arch_flag):
     _nvjitlinklib.destroy(handle)
 
 
-def test_get_linked_ptx_link_not_complete_error(device_functions_ltoir, gpu_arch_flag):
+def test_get_linked_ptx_link_not_complete_error(device_functions_ltoir_object, gpu_arch_flag):
     handle = _nvjitlinklib.create(gpu_arch_flag, "-lto", "-ptx")
-    filename, data = device_functions_ltoir
+    filename, data = device_functions_ltoir_object
     input_type = InputType.OBJECT.value
     _nvjitlinklib.add_data(handle, input_type, data, filename)
     with pytest.raises(RuntimeError, match="NVJITLINK_ERROR_INTERNAL error"):

--- a/pynvjitlink/tests/test_pynvjitlink_api.py
+++ b/pynvjitlink/tests/test_pynvjitlink_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
 
 import pytest
 import sys

--- a/pynvjitlink/tests/test_pynvjitlink_api.py
+++ b/pynvjitlink/tests/test_pynvjitlink_api.py
@@ -32,50 +32,50 @@ def test_create_and_destroy():
 
 def test_add_cubin(device_functions_cubin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.cubin"
-    nvjitlinker.add_cubin(device_functions_cubin, name)
+    name, cubin = device_functions_cubin
+    nvjitlinker.add_cubin(cubin, name)
 
 
 def test_add_incompatible_cubin_arch_error(device_functions_cubin, alt_gpu_arch_flag):
     nvjitlinker = NvJitLinker(alt_gpu_arch_flag)
-    name = "test_device_functions.cubin"
+    name, cubin = device_functions_cubin
     with pytest.raises(NvJitLinkError, match="NVJITLINK_ERROR_INVALID_INPUT error"):
-        nvjitlinker.add_cubin(device_functions_cubin, name)
+        nvjitlinker.add_cubin(cubin, name)
 
 
 def test_add_fatbin_arch_1(device_functions_fatbin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.fatbin"
-    nvjitlinker.add_fatbin(device_functions_fatbin, name)
+    name, fatbin = device_functions_fatbin
+    nvjitlinker.add_fatbin(fatbin, name)
 
 
 def test_add_fatbin_arch_2(device_functions_fatbin, alt_gpu_arch_flag):
     nvjitlinker = NvJitLinker(alt_gpu_arch_flag)
-    name = "test_device_functions.fatbin"
-    nvjitlinker.add_fatbin(device_functions_fatbin, name)
+    name, fatbin = device_functions_fatbin
+    nvjitlinker.add_fatbin(fatbin, name)
 
 
 def test_add_nonexistent_fatbin_arch_error(
     device_functions_fatbin, absent_gpu_arch_flag
 ):
     nvjitlinker = NvJitLinker(absent_gpu_arch_flag)
-    name = "test_device_functions.fatbin"
+    name, fatbin = device_functions_fatbin
     with pytest.raises(NvJitLinkError, match="NVJITLINK_ERROR_INVALID_INPUT error"):
-        nvjitlinker.add_fatbin(device_functions_fatbin, name)
+        nvjitlinker.add_fatbin(fatbin, name)
 
 
 def test_add_cubin_with_fatbin_error(device_functions_fatbin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.fatbin"
+    name, fatbin = device_functions_fatbin
     with pytest.raises(NvJitLinkError, match="NVJITLINK_ERROR_INVALID_INPUT error"):
-        nvjitlinker.add_cubin(device_functions_fatbin, name)
+        nvjitlinker.add_cubin(fatbin, name)
 
 
 def test_add_fatbin_with_cubin_error(device_functions_cubin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.cubin"
+    name, cubin = device_functions_cubin
     with pytest.raises(NvJitLinkError, match="NVJITLINK_ERROR_INVALID_INPUT error"):
-        nvjitlinker.add_fatbin(device_functions_cubin, name)
+        nvjitlinker.add_fatbin(cubin, name)
 
 
 def test_duplicate_symbols_cubin_and_fatbin(
@@ -84,11 +84,11 @@ def test_duplicate_symbols_cubin_and_fatbin(
     # This link errors because the cubin and the fatbin contain the same
     # symbols.
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.cubin"
-    nvjitlinker.add_cubin(device_functions_cubin, name)
-    name = "test_device_functions.fatbin"
+    name, cubin = device_functions_cubin
+    nvjitlinker.add_cubin(cubin, name)
+    name, fatbin = device_functions_fatbin
     with pytest.raises(NvJitLinkError, match="NVJITLINK_ERROR_INVALID_INPUT error"):
-        nvjitlinker.add_fatbin(device_functions_fatbin, name)
+        nvjitlinker.add_fatbin(fatbin, name)
 
 
 def test_get_linked_cubin_complete_empty_error():
@@ -101,8 +101,8 @@ def test_get_linked_cubin_complete_empty_error():
 
 def test_get_linked_cubin(device_functions_cubin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.cubin"
-    nvjitlinker.add_cubin(device_functions_cubin, name)
+    name, cubin = device_functions_cubin
+    nvjitlinker.add_cubin(cubin, name)
     cubin = nvjitlinker.get_linked_cubin()
 
     # Just check we got something that looks like an ELF
@@ -111,8 +111,8 @@ def test_get_linked_cubin(device_functions_cubin, gpu_arch_flag):
 
 def test_get_error_log(undefined_extern_cubin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "undefined_extern.cubin"
-    nvjitlinker.add_cubin(undefined_extern_cubin, name)
+    name, cubin = undefined_extern_cubin
+    nvjitlinker.add_cubin(cubin, name)
     with pytest.raises(NvJitLinkError):
         nvjitlinker.get_linked_cubin()
     error_log = nvjitlinker.error_log
@@ -121,8 +121,8 @@ def test_get_error_log(undefined_extern_cubin, gpu_arch_flag):
 
 def test_get_info_log(device_functions_cubin, gpu_arch_flag):
     nvjitlinker = NvJitLinker(gpu_arch_flag)
-    name = "test_device_functions.cubin"
-    nvjitlinker.add_cubin(device_functions_cubin, name)
+    name, cubin = device_functions_cubin
+    nvjitlinker.add_cubin(cubin, name)
     nvjitlinker.get_linked_cubin()
     info_log = nvjitlinker.info_log
     # Info log is empty

--- a/test_binary_generation/Makefile
+++ b/test_binary_generation/Makefile
@@ -41,11 +41,14 @@ all:
 	nvcc $(NVCC_FLAGS) $(CUBIN_FLAGS) -o $(OUTPUT_DIR)/undefined_extern.cubin undefined_extern.cu
 	nvcc $(NVCC_FLAGS) $(CUBIN_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.cubin test_device_functions.cu
 	nvcc $(NVCC_FLAGS) $(FATBIN_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.fatbin test_device_functions.cu
-	nvcc $(NVCC_FLAGS) $(LTOIR_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.ltoir test_device_functions.cu
 	nvcc $(NVCC_FLAGS) $(PTX_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.ptx test_device_functions.cu
 	nvcc $(NVCC_FLAGS) $(OBJECT_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.o test_device_functions.cu
 	nvcc $(NVCC_FLAGS) $(LIBRARY_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.a test_device_functions.cu
 
+	# Generate LTO-IR wrapped in a fatbin
+	nvcc $(NVCC_FLAGS) $(LTOIR_FLAGS) -o $(OUTPUT_DIR)/test_device_functions.ltoir.o test_device_functions.cu
+	# Generate LTO-IR in a "raw" LTO-IR container
+	python generate_raw_ltoir.py --arch sm_$(GPU_CC) -o $(OUTPUT_DIR)/test_device_functions.ltoir test_device_functions.cu
 	# We also want to test linking a .cu file; this needs no compilation,
 	# so copy it instead
 	cp test_device_functions.cu $(OUTPUT_DIR)

--- a/test_binary_generation/generate_raw_ltoir.py
+++ b/test_binary_generation/generate_raw_ltoir.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import argparse
+import pathlib
+import subprocess
+import sys
+
+from cuda import nvrtc
+
+# Magic number found at the start of an LTO-IR file
+LTOIR_MAGIC = 0x7F4E43ED
+
+
+def check(args):
+    """
+    Abort and print an error message in the presence of an error result.
+
+    Otherwise:
+    - Return None if there were no more arguments,
+    - Return the singular argument if there was only one further argument,
+    - Return the tuple of arguments if multiple followed.
+    """
+
+    result, *args = args
+    value = result.value
+
+    if value:
+        error_string = check(nvrtc.nvrtcGetErrorString(result)).decode()
+        msg = f"NVRTC error, code {value}: {error_string}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+    if len(args) == 0:
+        return None
+    elif len(args) == 1:
+        return args[0]
+    else:
+        return args
+
+
+def determine_include_path():
+    # Inspired by the logic in FindCUDA.cmake. We need the CUDA include path
+    # because NVRTC doesn't add it by default, and we can compile a much
+    # broader set of test files if the CUDA headers are available.
+
+    # We get NVCC to tell us the location of the CUDA Toolkit.
+
+    cmd = ['nvcc', '-v', '__dummy']
+    cp = subprocess.run(cmd, capture_output=True)
+
+    rc = cp.returncode
+    if rc != 1:
+        print(f"Unexpected return code ({rc}) from `nvcc -v`. Expected 1.")
+        return None
+
+    output = cp.stderr.decode()
+    lines = output.splitlines()
+
+    top_lines = [line for line in lines if line.startswith("#$ TOP=")]
+    if len(top_lines) != 1:
+        print(f"Expected exactly one TOP line. Got {len(top_lines)}.")
+        return None
+
+    # Parse out the path following "TOP="
+
+    top_dir = top_lines[0].split('TOP=')[1].strip()
+    include_dir = f"{top_dir}/include"
+    print(f"Using CUDA include dir {include_dir}")
+
+    # Sanity check the include dir
+
+    include_path = pathlib.Path(include_dir)
+    if not include_path.exists():
+        print("Include path appears not to exist", file=sys.stdout)
+        return None
+
+    if not include_path.is_dir():
+        print("Include path appears not to be a directory",
+              file=sys.stdout)
+        return None
+
+    cuda_h = include_path / "cuda.h"
+
+    if not cuda_h.exists():
+        print("cuda.h not found in CUDA in CUDA include location",
+              file=sys.stderr)
+        return None
+
+    if not cuda_h.is_file():
+        print("cuda.h is not a file", file=sys.stdout)
+        return None
+
+    # All is now well!
+
+    return include_dir
+
+
+def get_ltoir(source, name, arch):
+    """Given a CUDA C/C++ source, compile it and return the LTO-IR."""
+
+    program = check(nvrtc.nvrtcCreateProgram(source.encode(), name.encode(),
+                                             0, [], []))
+
+    cuda_include_path = determine_include_path()
+    if cuda_include_path is None:
+        print("Error determining CUDA include path. Exiting.", file=sys.stderr)
+        sys.exit(1)
+
+    options = [f'--gpu-architecture={arch}', '-dlto', '-rdc', 'true',
+               f'-I{cuda_include_path}']
+    options = [o.encode() for o in options]
+
+    result = nvrtc.nvrtcCompileProgram(program, len(options), options)
+
+    # Report compilation errors back to the user
+    if result[0] == nvrtc.nvrtcResult.NVRTC_ERROR_COMPILATION:
+        log_size = check(nvrtc.nvrtcGetProgramLogSize(program))
+        log = b' ' * log_size
+        check(nvrtc.nvrtcGetProgramLog(program, log))
+        print("NVRTC compilation error:\n", file=sys.stderr)
+        print(log.decode(), file=sys.stderr)
+        sys.exit(1)
+
+    # Handle other errors in the standard way
+    check(result)
+
+    ltoir_size = check(nvrtc.nvrtcGetLTOIRSize(program))
+    ltoir = b' ' * ltoir_size
+    check(nvrtc.nvrtcGetLTOIR(program, ltoir))
+
+    # Check that the output looks like an LTO-IR container
+    header = int.from_bytes(ltoir[:4], byteorder='little')
+    if header != LTOIR_MAGIC:
+        print(f"Unexpected header value 0x{header:X}.\n"
+              f"Expected LTO-IR magic number 0x{LTOIR_MAGIC:X}."
+              "\nExiting.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    return ltoir
+
+
+def main(sourcepath, outputpath, arch):
+    with open(sourcepath) as f:
+        source = f.read()
+
+    name = pathlib.Path(sourcepath).name
+    ltoir = get_ltoir(source, name, arch)
+
+    print(f"Writing {outputpath}...")
+
+    with open(outputpath, 'wb') as f:
+        f.write(ltoir)
+
+
+if __name__ == '__main__':
+    description = "Compiles CUDA C/C++ to LTO-IR using NVRTC."
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("sourcepath", help="path to source file")
+    parser.add_argument("-o", "--output", help="path to output file",
+                        default=None)
+    parser.add_argument("-a", "--arch",
+                        help="compute arch to target (e.g. sm_87). "
+                        "Defaults to sm_50.",
+                        default="sm_50")
+
+    args = parser.parse_args()
+    outputpath = args.output
+
+    if outputpath is None:
+        outputpath = pathlib.Path(args.sourcepath).with_suffix(".ltoir")
+
+    main(args.sourcepath, outputpath, args.arch)

--- a/test_binary_generation/generate_raw_ltoir.py
+++ b/test_binary_generation/generate_raw_ltoir.py
@@ -89,7 +89,7 @@ def get_ltoir(source, name, arch):
         "-dlto",
         "-rdc",
         "true",
-        *cuda_include_flags
+        *cuda_include_flags,
     ]
     options = [o.encode() for o in options]
 


### PR DESCRIPTION
#72 added support for linking LTO-IR files from memory instead of disk. However, it could not be tested because:

- We had no way to generate an LTO-IR container for the test input - NVCC doesn't support emitting an LTO-IR container, only an LTO-IR wrapped in a fatbin wrapped in a host object.
- The Numba patch needs to patch Numba for LTO for linking LTO-IR to work.

This PR implements both of the above, with these changes:

- Addition of a new test binary generator, `generate_raw_ltoir.py`. This uses NVRTC to generate an LTO-IR container. It uses the cuda-python bindings, so `cuda-python` is added to the test environments.
- The fixtures had ended up with some duplication and inconsistency between `conftest.py` and other test files, so these are deduplicated, and now kept in `conftest.py`. Appropriate updates to all tests using the fixtures are made.
- The `lto` kwarg is added to the `patch_numba_linker()` function. It is disabled by default, as enabling LTO will not presently work in all use cases.
- Added a test for linking LTO-IR from memory.

