### PR TITLE
Try pinning scikit-build-core 0.8.2

### DIFF
--- a/conda/recipes/pynvjitlink/meta.yaml
+++ b/conda/recipes/pynvjitlink/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}
     - python
     - pip
-    - scikit-build-core
+    - scikit-build-core 0.8.2
   run:
     - python
     - numba >=0.58

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+
 [tool.scikit-build]
 cmake.minimum-version = "3.26.4"
 cmake.verbose = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-dir = "build/{wheel_tag}"
 wheel.packages = ["pynvjitlink"]
 
 [build-system]
-requires = ["scikit-build-core"]
+requires = ["scikit-build-core==0.8.2"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Attempting to ensure that wheels receive the correct platform tags, i.e. `manylinux_2_17` and `manylinux_2_28` instead of `linux_x86-64` and `linux_aarch64` that the 0.2.2 wheels seemed to get.