### PR TITLE
README: Don't use extra index for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The [RAPIDS](https://rapids.ai) pynvjitlink library provides a Python binding fo
 ## Installation with pip
 
 ```shell
-pip install --extra-index-url https://pypi.nvidia.com pynvjitlink-cu12
+pip install pynvjitlink-cu12
 ```
 
 ## Installation from source


### PR DESCRIPTION
pynvjitlink wheels appear to be available on PyPI, so we should recommend that as the canonical location to use.

See: https://pypi.org/project/pynvjitlink-cu12/#files