### PR TITLE
Support Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,22 +15,13 @@ find_package(
   CUDAToolkit 12.2.140 REQUIRED
 )
 
-#set_target_properties(_nvjitlinklib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-#target_include_directories(_nvjitlinklib PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
 target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvptxcompiler_static)
-#target_link_libraries(_nvjitlinklib PRIVATE optimized CUDA::nvJitLink)
-target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvJitLink)
-
-#get_target_property(loc CUDA::nvJitLink_static LOCATION)
-#get_target_property(loc2 CUDA::nvJitLink LOCATION)
-
-#include(CMakePrintHelpers)
-#cmake_print_variables(loc)
-#cmake_print_variables(loc2)
-#cmake_print_variables(CUDAToolkit_INCLUDE_DIRS)
-
-
-#target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall)
+if (WIN32)
+    target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvJitLink)
+else()
+    target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvJitLink_static)
+    target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall)
+endif()
 
 target_compile_features(_nvjitlinklib PRIVATE cxx_std_11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 project(
   pynvjitlink
   VERSION ${SKBUILD_PROJECT_VERSION}
-  LANGUAGES CXX CUDA
+  LANGUAGES CXX
 )
 
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
@@ -14,9 +14,23 @@ find_package(
   # Require CUDA 12.2 Update 2 to avoid nvjitlink bugs
   CUDAToolkit 12.2.140 REQUIRED
 )
-target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvJitLink_static CUDA::nvptxcompiler_static)
 
-target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall)
+#set_target_properties(_nvjitlinklib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+#target_include_directories(_nvjitlinklib PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvptxcompiler_static)
+#target_link_libraries(_nvjitlinklib PRIVATE optimized CUDA::nvJitLink)
+target_link_libraries(_nvjitlinklib PRIVATE CUDA::nvJitLink)
+
+#get_target_property(loc CUDA::nvJitLink_static LOCATION)
+#get_target_property(loc2 CUDA::nvJitLink LOCATION)
+
+#include(CMakePrintHelpers)
+#cmake_print_variables(loc)
+#cmake_print_variables(loc2)
+#cmake_print_variables(CUDAToolkit_INCLUDE_DIRS)
+
+
+#target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall)
 
 target_compile_features(_nvjitlinklib PRIVATE cxx_std_11)
 

--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -16,6 +16,8 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "nvJitLink.h"
+// something funny going on with this macro on Windows...
+// see https://stackoverflow.com/a/62235644/2344149
 #ifdef _DEBUG
 #define __PYNVJIT_DEBUG _DEBUG
 #undef _DEBUG

--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -16,7 +16,15 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "nvJitLink.h"
+#ifdef _DEBUG
+#define __PYNVJIT_DEBUG _DEBUG
+#undef _DEBUG
 #include <Python.h>
+#define _DEBUG __PYNVJIT_DEBUG
+#undef __PYNVJIT_DEBUG
+#else
+#include <Python.h>
+#endif
 #include <new>
 
 static const char *nvJitLinkGetErrorEnum(nvJitLinkResult error) {


### PR DESCRIPTION
To be discussed internally...

There seems to be a complex interplay between CMake generators and CMake’s `CUDA` lang support…
- VS (default):
  - `CUDA` lang enabled:
    - Copy the [VS extension that Alex shared](https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/) to `%CONDA_PREFIX%\Library\extras\visual_studio_integration\MSBuildExtensions` (luckily CMake explicitly suggested this path so there’s no guess work)
    - Copy `cudart.lib`, `cudart_static.lib`, and `cudadevrt.lib` from `%CONDA_PREFIX%\Library\lib` to `%CONDA_PREFIX%\Library\lib\x64`. It seems this is what CMake-VS assumes (at nvcc detect stage)?!
    - Switch to do dynamic linking;  for static linking I hit LNK2038 error
    - Pass `--config-settings=cmake.args=-Tcuda=%CONDA_PREFIX%\Library -v .` to `pip`.
  - `CUDA` lang disabled (so only `CXX` being listed):
    - Switch to do dynamic linking;  for static linking I hit LNK2038 error
    - Simplest solution, taken in this PR. (This repo does not have CUDA code so does not need `CUDA` lang anyway, it was an overkill.)
- Ninja:
  - `CUDA` lang enabled/disabled: error (either header not found or unresolved symbols; it seems Ninja on Windows does not generate right compiler/linker flags…