### PR TITLE
[DO NOT MERGE] ref new codecovcli upload command

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,14 +46,14 @@ jobs:
       script: "ci/build_conda.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.BUILD_MATRIX }}
   test-conda:
+    secrets: inherit
     needs:
       - build-conda
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test_codecovcli_source
     with:
       build_type: pull-request
       script: "ci/test_conda.sh"
-      matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
   test-patch:
     needs:
       - build-conda

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,5 +81,3 @@ jobs:
       build_type: pull-request
       script: "ci/test_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
-
-      

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,3 +81,5 @@ jobs:
       build_type: pull-request
       script: "ci/test_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
+
+      

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,4 +80,4 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_wheel.sh"
-      matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
+      matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }} 


### PR DESCRIPTION
This PR is primarily to confirm that the `codecovcli` invocation at least gets past the `Error loading Python lib '/tmp/_MEImwrRwT/libpython3.11.so.1.0': dlopen: /usr/lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /tmp/_MEImwrRwT/libpython3.11.so.1.0)` reported [here](https://github.com/rapidsai/ci-imgs/pull/142#issue-2328451536).

These tests show that we're able to acheive this with the source distribution variant of the codecovcli (0.6.0) package.
- https://github.com/rapidsai/pynvjitlink/actions/runs/9371539018/job/25801234092?pr=87
- https://github.com/rapidsai/pynvjitlink/actions/runs/9371539018/job/25801234433?pr=87

A second test was carried out [in this job](https://github.com/rapidsai/literate-octo-potato/actions/runs/9370643165/job/25798101533?pr=827) which used the same installation format (source dist).

Accompanying `shared-workflows` PR is linked [here](https://github.com/rapidsai/shared-workflows/pull/215).