### PR TITLE
WIP: make conda recipe data-loading stricter

### DIFF
--- a/conda/recipes/pynvjitlink/meta.yaml
+++ b/conda/recipes/pynvjitlink/meta.yaml
@@ -5,7 +5,7 @@
     load_file="pynvjitlink/VERSION",
     regex_pattern="(?P<value>.*)"
 )[0] %}
-{% set project_data = data.get("project") %}
+{% set project_data = data["project"] %}
 {% set project_urls = project_data["urls"] %}
 
 package:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/72.

Proposes replacing a use of `.get()` in the conda recipe with `[]`, to ensure that we get a loud build error if the `"project"` table is not present when `conda-build` reads `pyproject.toml`.

## Notes for Reviewers

I know that at some time in the past, the `.get()` was introduced as a possible solution for errors observed at build time: https://github.com/rapidsai/pynvjitlink/pull/33#discussion_r1449525892

Pushing this to see if those are still an issue.