### PR TITLE
Provide nvJitLinkVersion as a public API.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.08
     with:
       build_type: branch
@@ -32,7 +31,6 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.08
     with:
       build_type: branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.08
     with:
       build_type: branch
@@ -31,6 +32,7 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.08
     with:
       build_type: branch

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,6 +40,7 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.08
     with:
       build_type: pull-request
@@ -59,6 +60,7 @@ jobs:
     needs:
       - build-conda
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.08
     with:
       build_type: pull-request
@@ -68,6 +70,7 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.08
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,6 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.08
     with:
       build_type: pull-request
@@ -60,7 +59,6 @@ jobs:
     needs:
       - build-conda
       - compute-matrix
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.08
     with:
       build_type: pull-request
@@ -70,7 +68,6 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.08
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,6 +49,7 @@ jobs:
     needs:
       - build-conda
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.08
     with:
       build_type: pull-request
@@ -76,6 +77,7 @@ jobs:
     needs:
       - build-wheels
       - compute-matrix
+    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.08
     with:
       build_type: pull-request

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 build
+dist
+final_dist
 *.so
 *.egg-info
 .*.swp

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -12,7 +12,8 @@ rapids-logger "Build wheel"
 mkdir -p ./dist
 python -m pip wheel . --wheel-dir=./dist -vvv --disable-pip-version-check --no-deps
 
-python -m auditwheel repair -w ./final_dist ./dist/*
+# Exclude libcuda.so.1 because we only install a driver stub
+python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*
 
 rapids-logger "Upload Wheel"
 RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ./final_dist

--- a/ci/install_latest_cuda_toolkit.sh
+++ b/ci/install_latest_cuda_toolkit.sh
@@ -13,4 +13,4 @@ if [ "${OS_ID}" != "rocky" ]; then
     exit 1
 fi
 
-yum install -y nvidia-driver cuda-nvcc-12-5 cuda-cudart-devel-12-5 cuda-driver-devel-12-5 libnvjitlink-devel-12-5
+yum install -y cuda-nvcc-12-5 cuda-cudart-devel-12-5 cuda-driver-devel-12-5 libnvjitlink-devel-12-5

--- a/ci/install_latest_cuda_toolkit.sh
+++ b/ci/install_latest_cuda_toolkit.sh
@@ -2,17 +2,15 @@
 # Copyright (c) 2024, NVIDIA CORPORATION
 
 # Installs the latest CUDA Toolkit.
-# Supports CentOS 7 and Rocky Linux 8.
+# Supports Rocky Linux 8.
 
 yum update -y
 yum install -y epel-release
 
 OS_ID=$(. /etc/os-release; echo $ID)
-if [ "${OS_ID}" == "rocky" ]; then
-    yum install -y nvidia-driver
-else
+if [ "${OS_ID}" != "rocky" ]; then
     echo "Error: OS not detected as Rocky Linux. Exiting."
     exit 1
 fi
 
-yum install -y cuda-toolkit-12-5
+yum install -y nvidia-driver cuda-nvcc-12-5 cuda-cudart-devel-12-5 cuda-driver-devel-12-5 libnvjitlink-devel-12-5

--- a/pynvjitlink/__init__.py
+++ b/pynvjitlink/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
-from pynvjitlink.api import NvJitLinker, NvJitLinkError
+from pynvjitlink.api import NvJitLinker, NvJitLinkError, nvjitlink_version
 from pynvjitlink._version import __git_commit__, __version__
 
 __all__ = [
     "NvJitLinkError",
     "NvJitLinker",
+    "nvjitlink_version",
     "__git_commit__",
     "__version__",
 ]

--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,40 @@ static void set_exception(PyObject *exception_type, const char *message_format,
   sprintf(exception_message, message_format, nvJitLinkGetErrorEnum(error));
 
   PyErr_SetString(exception_type, exception_message);
+}
+
+static PyObject *nvjitlink_version() {
+  unsigned int major;
+  unsigned int minor;
+
+  nvJitLinkResult res = nvJitLinkVersion(&major, &minor);
+
+  if (res != NVJITLINK_SUCCESS) {
+    set_exception(PyExc_RuntimeError, "%s error when calling nvJitLinkVersion",
+                  res);
+    return nullptr;
+  }
+
+  PyObject *py_version = PyTuple_New(2);
+  PyObject *py_major = PyLong_FromUnsignedLong(major);
+  PyObject *py_minor = PyLong_FromUnsignedLong(minor);
+  if (!py_version || !py_major || !py_minor) {
+    PyErr_SetString(PyExc_RuntimeError, "Failed to create version tuple");
+    if (py_major) {
+      Py_DecRef(py_major);
+    }
+    if (py_minor) {
+      Py_DecRef(py_minor);
+    }
+    if (py_version) {
+      Py_DecRef(py_version);
+    }
+    return nullptr;
+  }
+
+  PyTuple_SetItem(py_version, 0, py_major);
+  PyTuple_SetItem(py_version, 1, py_minor);
+  return py_version;
 }
 
 static PyObject *create(PyObject *self, PyObject *args) {
@@ -302,6 +336,8 @@ static PyObject *get_linked_cubin(PyObject *self, PyObject *args) {
 }
 
 static PyMethodDef ext_methods[] = {
+    {"nvjitlink_version", (PyCFunction)nvjitlink_version, METH_VARARGS,
+     "Returns the nvJitLink version"},
     {"create", (PyCFunction)create, METH_VARARGS,
      "Returns a handle to a new nvJitLink object"},
     {"destroy", (PyCFunction)destroy, METH_VARARGS,

--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -55,7 +55,7 @@ static void set_exception(PyObject *exception_type, const char *message_format,
   PyErr_SetString(exception_type, exception_message);
 }
 
-static PyObject *nvjitlink_version() {
+static PyObject *nvjitlink_version(PyObject *self, PyObject *Py_UNUSED(args)) {
   unsigned int major;
   unsigned int minor;
 
@@ -336,7 +336,7 @@ static PyObject *get_linked_cubin(PyObject *self, PyObject *args) {
 }
 
 static PyMethodDef ext_methods[] = {
-    {"nvjitlink_version", (PyCFunction)nvjitlink_version, METH_VARARGS,
+    {"nvjitlink_version", (PyCFunction)nvjitlink_version, METH_NOARGS,
      "Returns the nvJitLink version"},
     {"create", (PyCFunction)create, METH_VARARGS,
      "Returns a handle to a new nvJitLink object"},

--- a/pynvjitlink/api.py
+++ b/pynvjitlink/api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 from enum import Enum
 from pynvjitlink import _nvjitlinklib
@@ -14,6 +14,10 @@ class InputType(Enum):
     FATBIN = 4
     OBJECT = 5
     LIBRARY = 6
+
+
+def nvjitlink_version():
+    return _nvjitlinklib.nvjitlink_version()
 
 
 class NvJitLinkError(RuntimeError):

--- a/pynvjitlink/tests/test_version.py
+++ b/pynvjitlink/tests/test_version.py
@@ -10,3 +10,10 @@ def test_version_constants_are_populated():
     # __version__ should always be non-empty
     assert isinstance(pynvjitlink.__version__, str)
     assert len(pynvjitlink.__version__) > 0
+
+
+def test_nvjitlink_version():
+    nvjitlink_version = pynvjitlink.nvjitlink_version()
+    assert len(nvjitlink_version) == 2
+    assert nvjitlink_version[0] >= 12
+    assert nvjitlink_version[1] >= 0

--- a/pynvjitlink/tests/test_version.py
+++ b/pynvjitlink/tests/test_version.py
@@ -13,7 +13,6 @@ def test_version_constants_are_populated():
 
 
 def test_nvjitlink_version():
-    nvjitlink_version = pynvjitlink.nvjitlink_version()
-    assert len(nvjitlink_version) == 2
-    assert nvjitlink_version[0] >= 12
-    assert nvjitlink_version[1] >= 0
+    major, minor = pynvjitlink.nvjitlink_version()
+    assert major >= 12
+    assert minor >= 0


### PR DESCRIPTION
Resolves #38 by making the result of `nvJitLinkVersion` a public API.
