### PR TITLE
Enable release wheels publish to pypi

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: pynvjitlink
+      publish_to_pypi: true
   publish-conda:
     needs:
      - build-conda


### PR DESCRIPTION
Enables wheels publish to `pypi.org`.

NOTE: At the time of this PR, only wheels from release builds are published to PyPI. See https://github.com/rapidsai/shared-workflows/pull/225.