### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/conda/recipes/pynvjitlink/meta.yaml
+++ b/conda/recipes/pynvjitlink/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}
-    - cmake >=3.26.4
+    - cmake >=3.26.4,!=3.30.0
     - ninja
     - sysroot_{{ target_platform }} 2.17
   host:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.
