### PR TITLE
Use `build-system.requires` to set scikit-build-core minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies-file = "dependencies.yaml"
 [tool.scikit-build]
 build.verbose = true
 cmake.version = "CMakeLists.txt"
-minimum-version = "0.10"
+minimum-version = "build-system.requires"
 ninja.make-fallback = true
 build-dir = "build/{wheel_tag}"
 wheel.packages = ["pynvjitlink"]


### PR DESCRIPTION
As pointed out by Henry ( https://github.com/rapidsai/build-planning/issues/58#issuecomment-2274214167 ), we can configure `scikit-build-core` to retrieve the minimum version from `build-system.requires`

This is also mentioned in:

* [This blogpost]( https://iscinumpy.dev/post/scikit-build-core-0-10/ )
* [The scikit-build-core docs]( https://scikit-build-core.readthedocs.io/en/latest/configuration.html#minimum-version-defaults )