### PR TITLE
Build with the Python limited API.

### DIFF
--- a/.github/actions/compute-matrix/action.yaml
+++ b/.github/actions/compute-matrix/action.yaml
@@ -16,19 +16,13 @@ runs:
         set -eo pipefail
 
         export BUILD_MATRIX="
-        - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
         - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
         - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
         "
 
         export TEST_MATRIX="
-          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'ubuntu20.04', gpu: 'v100', driver: 'latest' }
           - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'ubuntu20.04', gpu: 'v100', driver: 'latest' }
           - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'ubuntu20.04', gpu: 'v100', driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
           - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
           - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
         "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ project(
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
 Python_add_library(_nvjitlinklib MODULE pynvjitlink/_nvjitlinklib.cpp WITH_SOABI)
+target_compile_definitions(
+    _nvjitlinklib
+    # Target Python 3.11, the earliest version to support the buffer protocol.
+    PRIVATE Py_LIMITED_API=0x030B0000
+)
 
 find_package(
   # Require CUDA 12.2 Update 2 to avoid nvjitlink bugs

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -15,5 +15,8 @@ python -m pip wheel . --wheel-dir=./dist -vvv --disable-pip-version-check --no-d
 # Exclude libcuda.so.1 because we only install a driver stub
 python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*
 
+python -m pip install abi3audit
+abi3audit ./final_dist/*.whl
+
 rapids-logger "Upload Wheel"
 RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ./final_dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -16,6 +16,7 @@ python -m pip wheel . --wheel-dir=./dist -vvv --disable-pip-version-check --no-d
 python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*
 
 python -m pip install abi3audit
+pyenv rehash
 abi3audit ./final_dist/*.whl
 
 rapids-logger "Upload Wheel"

--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -17,6 +17,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "nvJitLink.h"
 #include <Python.h>
+#include <cstdio>
 #include <new>
 
 static const char *nvJitLinkGetErrorEnum(nvJitLinkResult error) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ minimum-version = "build-system.requires"
 ninja.make-fallback = true
 build-dir = "build/{wheel_tag}"
 wheel.packages = ["pynvjitlink"]
+wheel.py-api = "cp311"
 
 [build-system]
 requires = [


### PR DESCRIPTION
<!--

Thank you for contributing to pynvjitlink :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
I noticed discussion on https://github.com/rapidsai/pynvjitlink/issues/21 around supported Python versions last week and it got me thinking about whether pynvjitlink really needs Python version-specific packages. pynvjitlink uses the C API directly, and it uses a pretty minimal subset, so we can actually just build it with the limited API and get a package compatible across Python versions. I tested the built wheel on 3.11 and 3.12 and tests pass just fine, at least locally.

The main blocker is that we require the limited API as of Python 3.11 (namely support for the buffer protocol) to make this switch. We _just_ dropped support for Python 3.9, so we're likely a year out from dropping 3.10. If we do think that the limited API is a path work exploring, our two options are to simply keep this PR around as a reminder until we drop 3.10, or to bifurcate our build into a 3.10 path and a 3.11+ path. I don't think the latter would be too painful to maintain. It would require three things that I can think of off the top of my head: 1) updating test jobs to download the abi3 wheel for Python>3.11 instead of one specific to their version (so in general, some of the improvements needed for https://github.com/rapidsai/build-planning/issues/43); 2) specifying `wheel.py-api` via a config-settings flag in build_wheel.sh for Python 3.10; and 3) updating the conda recipes accordingly to set the right run exports for the abi3 packages.

A middle ground might be to do nothing now, but the next time someone asks for support for Python 3.13 we switch to the limited API instead.

Since pynvjitlink has users beyond just RAPIDS, making the change here seems beneficial so that pynvjitlink can uncouple from the Python upgrade cycle of RAPIDS.