### PR TITLE
Use conda strict channel priority.

### DIFF
--- a/ci/build_conda.sh
+++ b/ci/build_conda.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+conda config --set channel_priority strict
+
 rapids-configure-conda-channels
 
 source rapids-configure-sccache

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
+conda config --set channel_priority strict
+
 rapids-logger "Install testing dependencies"
 
 ENV_YAML_DIR="$(mktemp -d)"

--- a/ci/test_patch.sh
+++ b/ci/test_patch.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
+conda config --set channel_priority strict
+
 rapids-logger "Install testing dependencies"
 
 ENV_YAML_DIR="$(mktemp -d)"


### PR DESCRIPTION
This attempts to resolve some issues with CUDA packages being pulled from both `conda-forge` and `nvidia` channels by using strict channel priority.

The `nvidia` channel should not be needed for this package.
