### PR TITLE
use sccache, print sccache stats in builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.13.11
+    rev: v1.16.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]
@@ -19,7 +19,7 @@ repos:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.1.0
+    rev: v0.4.0
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]

--- a/ci/build_conda.sh
+++ b/ci/build_conda.sh
@@ -24,9 +24,13 @@ cuda_compiler_version:
   - "${CUDA_VERSION}"
 EOF
 
+sccache --zero-stats
+
 rapids-conda-retry build \
     conda/recipes/pynvjitlink \
     -m cuda_compiler_version.yaml \
 ;
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -20,4 +20,4 @@ sccache --show-adv-stats
 python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*
 
 rapids-logger "Upload Wheel"
-RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ./final_dist
+RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python ./final_dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -8,9 +8,13 @@ source "$(dirname "$0")/install_latest_cuda_toolkit.sh"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
+sccache --zero-stats
+
 rapids-logger "Build wheel"
 mkdir -p ./dist
-python -m pip wheel . --wheel-dir=./dist -vvv --disable-pip-version-check --no-deps
+python -m pip wheel . --wheel-dir=./dist -v --disable-pip-version-check --no-deps
+
+sccache --show-adv-stats
 
 # Exclude libcuda.so.1 because we only install a driver stub
 python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-configure-sccache
+
 rapids-logger "Install CUDA Toolkit"
 source "$(dirname "$0")/install_latest_cuda_toolkit.sh"
 

--- a/conda/recipes/pynvjitlink/meta.yaml
+++ b/conda/recipes/pynvjitlink/meta.yaml
@@ -18,6 +18,22 @@ source:
 build:
   script:
     - {{ PYTHON }} -m pip install . -vv
+  script_env:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_GENERATOR
+    - PARALLEL_LEVEL
+    - SCCACHE_BUCKET
+    - SCCACHE_IDLE_TIMEOUT
+    - SCCACHE_REGION
+    - SCCACHE_S3_KEY_PREFIX=pynvjitlink-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=pynvjitlink-linux64 # [linux64]
+    - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
     - {{ compiler('cuda') }}
     - libnvjitlink-dev


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/111

Proposes some small packaging/CI changes, matching similar changes being made across RAPIDS.

* printing `sccache` stats to CI logs
* updating to the latest `rapids-dependency-file-generator` (v1.16.0) and `rapidsai/pre-commit-hooks` (v0.4.0)
* always explicitly specifying `python` in calls to `rapids-upload-wheels-to-s3`

While doing that, I also noticed this project wasn't using `sccache`. This PR proposes using `sccache` to drive compilation, to speed up builds a bit.