### PR TITLE
enable publishes to nightly anaconda on pushes to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
The workflow setup currently does not publish to https://anaconda.org/rapidsai-nightly and only publishes to https://anaconda.org/rapidsai (via tags); this introduces an issue where conda solves which use the `rapisai-nightly` channel fails.

So this PR updates the setup to publish to `rapidsai-nightly` on pushes to main.