### PR TITLE
In Conda builds use GLIBC 2.28 + GCC 13

### DIFF
--- a/conda/recipes/pynvjitlink/conda_build_config.yaml
+++ b/conda/recipes/pynvjitlink/conda_build_config.yaml
@@ -8,7 +8,7 @@ c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - 2.17
+  - 2.28
 
 cuda_compiler:
   - cuda-nvcc

--- a/conda/recipes/pynvjitlink/conda_build_config.yaml
+++ b/conda/recipes/pynvjitlink/conda_build_config.yaml
@@ -1,8 +1,8 @@
 c_compiler_version:
-  - 11
+  - 13
 
 cxx_compiler_version:
-  - 11
+  - 13
 
 c_stdlib:
   - sysroot


### PR DESCRIPTION
Update Conda's sysroot version to match the image version of GLIBC 2.28. Also update the compilers to use GCC 13 as is already the case throughout RAPIDS.

Part of issues:
* https://github.com/rapidsai/build-planning/issues/131
* https://github.com/rapidsai/build-planning/issues/129