### PR TITLE
disallow fallback to Make in Python builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
 
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies-file = "dependencies.yaml"
 build.verbose = true
 cmake.version = "CMakeLists.txt"
 minimum-version = "build-system.requires"
-ninja.make-fallback = true
+ninja.make-fallback = false
 build-dir = "build/{wheel_tag}"
 wheel.packages = ["pynvjitlink"]
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/146

Proposes:

* setting `[tool.scikit-build].ninja.make-fallback = false`, so `scikit-build-core` will not silently fallback to using GNU Make if `ninja` is not available