### PR TITLE
Add shellcheck to pre-commit and fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+        files: ^ci/

--- a/ci/build_conda.sh
+++ b/ci/build_conda.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 
 set -euo pipefail
 
@@ -17,7 +17,8 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-export CUDA_VERSION="$(cat pynvjitlink/CUDA_VERSION)"
+CUDA_VERSION="$(cat pynvjitlink/CUDA_VERSION)"
+export CUDA_VERSION
 
 cat > cuda_compiler_version.yaml << EOF
 cuda_compiler_version:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION
+# Copyright (c) 2023-2025, NVIDIA CORPORATION
 
 set -euo pipefail
 
@@ -8,7 +8,7 @@ source rapids-configure-sccache
 rapids-logger "Install CUDA Toolkit"
 source "$(dirname "$0")/install_latest_cuda_toolkit.sh"
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 sccache --zero-stats
 

--- a/ci/install_latest_cuda_toolkit.sh
+++ b/ci/install_latest_cuda_toolkit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 
 # Installs the latest CUDA Toolkit.
 # Supports Rocky Linux 8.
@@ -13,12 +13,14 @@ if [ "${OS_ID}" != "rocky" ]; then
     exit 1
 fi
 
-export CUDA_VERSION="$(cat pynvjitlink/CUDA_VERSION)"
-export YUM_CUDA_VERSION="${CUDA_VERSION//./-}"
+CUDA_VERSION="$(cat pynvjitlink/CUDA_VERSION)"
+export CUDA_VERSION
+YUM_CUDA_VERSION="${CUDA_VERSION//./-}"
+export YUM_CUDA_VERSION
 
 yum install -y \
-    cuda-nvcc-$YUM_CUDA_VERSION \
-    cuda-cudart-devel-$YUM_CUDA_VERSION \
-    cuda-driver-devel-$YUM_CUDA_VERSION \
-    libnvjitlink-devel-$YUM_CUDA_VERSION \
+    cuda-nvcc-"$YUM_CUDA_VERSION" \
+    cuda-cudart-devel-"$YUM_CUDA_VERSION" \
+    cuda-driver-devel-"$YUM_CUDA_VERSION" \
+    libnvjitlink-devel-"$YUM_CUDA_VERSION" \
 ;

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 ## Usage
 # bash update-version.sh <new_version>
@@ -12,7 +12,7 @@ echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 # Centralized version file update

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION
+# Copyright (c) 2023-2025, NVIDIA CORPORATION
 
 set -euo pipefail
 
 rapids-logger "Download Wheel"
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist/
 
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 rapids-logger "Install wheel"
-python -m pip install $(echo ./dist/pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]
+python -m pip install "$(echo ./dist/pynvjitlink_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
 
 rapids-logger "Build Tests"
 pushd test_binary_generation


### PR DESCRIPTION
`shellcheck` is a fast, static analysis tool for shell scripts. It's good at
flagging up unused variables, unintentional glob expansions, and other potential
execution and security headaches that arise from the wonders of `bash` (and
other shlangs).

This PR adds a `pre-commit` hook to run `shellcheck` on all of the `sh-lang`
files in the `ci/` directory, and the changes requested by `shellcheck` to make
the existing files pass the check.

xref: rapidsai/build-planning#135
