### PR TITLE
Raise when pynvjitlink is in use with Numba-CUDA

### DIFF
--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -55,7 +55,7 @@ if spec is not None:
 
     import numba_cuda
 
-    numba_cuda_ver = (int(x) for x in numba_cuda.__version__.split("."))
+    numba_cuda_ver = tuple(int(x) for x in numba_cuda.__version__.split("."))
     if numba_cuda_ver < (0, 2, 0):
         suggestion = "Instead, use NUMBA_CUDA_ENABLE_PYNVJITLINK environment variable to enable pynvjitlink features."
     else:

--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -60,6 +60,8 @@ if spec is not None:
         suggestion = "Instead, use NUMBA_CUDA_ENABLE_PYNVJITLINK environment variable to enable pynvjitlink features."
     else:
         suggestion = "Instead, use config.CUDA_ENABLE_PYNVJITLINK option to enable pynvjitlink features."
+
+    _numba_cuda_error += suggestion
 else:
     _numba_cuda_in_use = False
 

--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -9,12 +9,10 @@ from pynvjitlink.api import NvJitLinker, NvJitLinkError
 _numba_version_ok = False
 _numba_error = None
 
-_numba_cuda_version_ok = False
 _numba_cuda_in_use = False
 _numba_cuda_error = None
 
 required_numba_ver = (0, 58)
-max_numba_cuda_ver = (0, 0, 18)
 
 mvc_docs_url = (
     "https://numba.readthedocs.io/en/stable/cuda/" "minor_version_compatibility.html"
@@ -53,7 +51,15 @@ else:
 spec = importlib.util.find_spec("numba_cuda")
 if spec is not None:
     _numba_cuda_in_use = True
-    _numba_cuda_error = "`numba_cuda` includes patches from pynvjitlink, so no further patches are needed."
+    _numba_cuda_error = "`numba_cuda` includes patches from pynvjitlink, so no further patches are needed. "
+
+    import numba_cuda
+
+    numba_cuda_ver = (int(x) for x in numba_cuda.__version__.split("."))
+    if numba_cuda_ver < (0, 2, 0):
+        suggestion = "Instead, use NUMBA_CUDA_ENABLE_PYNVJITLINK environment variable to enable pynvjitlink features."
+    else:
+        suggestion = "Instead, use config.CUDA_ENABLE_PYNVJITLINK option to enable pynvjitlink features."
 else:
     _numba_cuda_in_use = False
 


### PR DESCRIPTION
This PR raises when numba_cuda is in use and user attempts to invoke `patch_numba_linker`. Instead, user should attempt to enable pynvjitlinker via `CUDA_ENABLE_PYNVJITLINK` config. I believe this should close https://github.com/rapidsai/pynvjitlink/issues/117