### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.13
     with:
       build_type: branch
       script: "ci/build_wheel.sh"
@@ -33,7 +33,7 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.13
     with:
       build_type: branch
       script: "ci/build_conda.sh"
@@ -42,7 +42,7 @@ jobs:
     needs:
       - build-wheels
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -54,7 +54,7 @@ jobs:
     needs:
      - build-conda
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,10 +21,10 @@ jobs:
       - test-wheels
       - test-patch
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@python-3.13
   checks:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@python-3.13
     with:
       enable_check_generated_files: false
   compute-matrix:
@@ -40,7 +40,7 @@ jobs:
   build-conda:
     needs:
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.13
     with:
       build_type: pull-request
       script: "ci/build_conda.sh"
@@ -50,7 +50,7 @@ jobs:
       - build-conda
       - compute-matrix
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.13
     with:
       build_type: pull-request
       script: "ci/test_conda.sh"
@@ -59,7 +59,7 @@ jobs:
     needs:
       - build-conda
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.13
     with:
       build_type: pull-request
       script: "ci/test_patch.sh"
@@ -68,7 +68,7 @@ jobs:
   build-wheels:
     needs:
       - compute-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.13
     with:
       build_type: pull-request
       script: "ci/build_wheel.sh"
@@ -78,7 +78,7 @@ jobs:
       - build-wheels
       - compute-matrix
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.13
     with:
       build_type: pull-request
       script: "ci/test_wheel.sh"

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,7 +12,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@branch-25.02
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@python-3.13
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,8 +84,12 @@ dependencies:
             packages:
               - python=3.12
           - matrix:
+              py: "3.13"
             packages:
-              - python>=3.10,<3.13
+              - python=3.13
+          - matrix:
+            packages:
+              - python>=3.10,<3.14
   run:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/120

This PR adds support for Python 3.13.

## Notes for Reviewers

This is part of ongoing work to add Python 3.13 support across RAPIDS.
It temporarily introduces a build/test matrix including Python 3.13, from https://github.com/rapidsai/shared-workflows/pull/268.

A follow-up PR will revert back to pointing at the `branch-25.04` branch of `shared-workflows` once all
RAPIDS repos have added Python 3.13 support.

### This will fail until all dependencies have been updates to Python 3.13

CI here is expected to fail until all of this project's upstream dependencies support Python 3.13.

This can be merged whenever all CI jobs are passing.
