### PR TITLE
Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
       build_type: branch
       script: "ci/build_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.BUILD_MATRIX }}
+      wheel-name: pynvjitlink
+      package-type: python
   build-conda:
     needs:
       - compute-matrix

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,6 +73,8 @@ jobs:
       build_type: pull-request
       script: "ci/build_wheel.sh"
       matrix_filter: ${{ needs.compute-matrix.outputs.BUILD_MATRIX }}
+      wheel-name: pynvjitlink
+      package-type: python
   test-wheels:
     needs:
       - build-wheels

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 source rapids-configure-sccache
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 rapids-logger "Install CUDA Toolkit"
 source "$(dirname "$0")/install_latest_cuda_toolkit.sh"
 
@@ -19,7 +21,7 @@ rapids-pip-retry wheel . --wheel-dir=./dist -v --disable-pip-version-check --no-
 sccache --show-adv-stats
 
 # Exclude libcuda.so.1 because we only install a driver stub
-python -m auditwheel repair --exclude libcuda.so.1 -w ./final_dist ./dist/*
+python -m auditwheel repair --exclude libcuda.so.1 -w "${wheel_dir}" ./dist/*
 
 rapids-logger "Upload Wheel"
-RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python ./final_dist
+RAPIDS_PY_WHEEL_NAME="pynvjitlink_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${wheel_dir}"


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

As part of these changes, all wheel builds need to be in a specified temporary directory indicated by the environment variable `RAPIDS_WHEEL_BLD_OUTPUT_DIR` set on the `ci-wheel` Docker image used for building wheels. This lets us upload all wheel artifacts seamlessly to Github Artifacts. 