### PR TITLE
Change `PKG_HASH` to `hash`

### DIFF
--- a/conda/recipes/pynvjitlink/recipe.yaml
+++ b/conda/recipes/pynvjitlink/recipe.yaml
@@ -18,7 +18,7 @@ source:
 build:
   dynamic_linking:
     overlinking_behavior: error
-  string: ${{ cuda_version }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ PKG_HASH }}
+  string: ${{ cuda_version }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ hash }}
   script:
     content: |
       python -m pip install . -vv


### PR DESCRIPTION
Using `PKG_HASH` to embed the hash in the package's `string` works in conda-build recipes and does occur in the rattler-build docs. However for some reason it is not working here. Following upstream: https://github.com/prefix-dev/rattler-build/issues/1622

Switching to [`hash`]( https://rattler.build/latest/reference/jinja/#the-hash-variable ) appears to work and achieve the intended goal
