### PR TITLE
Quote head_rev in conda recipes

### DIFF
--- a/conda/recipes/pynvjitlink/recipe.yaml
+++ b/conda/recipes/pynvjitlink/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 context:
   cuda_version: ${{ load_from_file("pynvjitlink/CUDA_VERSION") | trim }}
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
   version: ${{ load_from_file("pynvjitlink/VERSION") | trim }}


### PR DESCRIPTION
This quotes `head_rev` to ensure that commits with leading zeros in the git SHA include those zeros in the output package name.

xref: https://github.com/rapidsai/build-planning/issues/176
