### PR TITLE
Update to clang 20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v20.1.4
     hooks:
       - id: clang-format
   - repo: https://github.com/rapidsai/dependency-file-generator


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/177

This PR updates the clang version to 20.
