### PR TITLE
Update CI images (update CUDA 12.8.0 to 12.9.1, update Ubuntu 20.04 to 22.04)

### DIFF
--- a/.github/actions/compute-matrix/action.yaml
+++ b/.github/actions/compute-matrix/action.yaml
@@ -16,25 +16,25 @@ runs:
         set -eo pipefail
 
         export BUILD_MATRIX="
-        - { CUDA_VER: '12.8.0', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'amd64', PY_VER: '3.13', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
-        - { CUDA_VER: '12.8.0', ARCH: 'arm64', PY_VER: '3.13', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'amd64', PY_VER: '3.13', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'rockylinux8' }
+        - { CUDA_VER: '12.9.1', ARCH: 'arm64', PY_VER: '3.13', LINUX_VER: 'rockylinux8' }
         "
 
         export TEST_MATRIX="
-          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'ubuntu20.04', gpu: 'l4',   driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'ubuntu20.04', gpu: 'l4',   driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'ubuntu20.04', gpu: 'l4',   driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.13', LINUX_VER: 'ubuntu20.04', gpu: 'l4',   driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
-          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.13', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.11', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.12', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.13', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.11', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.12', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'latest' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.13', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'latest' }
         "
 
         echo "BUILD_MATRIX=$(


### PR DESCRIPTION
This PR updates CI images for CUDA and Ubuntu to versions supported in the RAPIDS CI images matrix.
