### PR TITLE
Convert . in CUDA version to _ for rattler-build compat

### DIFF
--- a/conda/recipes/pynvjitlink/recipe.yaml
+++ b/conda/recipes/pynvjitlink/recipe.yaml
@@ -18,7 +18,7 @@ source:
 build:
   dynamic_linking:
     overlinking_behavior: error
-  string: ${{ cuda_version }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ hash }}
+  string: ${{ cuda_version.replace(".", "_") }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ hash }}
   script:
     content: |
       python -m pip install . -vv

--- a/conda/recipes/pynvjitlink/recipe.yaml
+++ b/conda/recipes/pynvjitlink/recipe.yaml
@@ -18,7 +18,7 @@ source:
 build:
   dynamic_linking:
     overlinking_behavior: error
-  string: ${{ cuda_version.replace(".", "_") }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ hash }}
+  string: ${{ cuda_version | replace(".", "_") }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}_h${{ hash }}
   script:
     content: |
       python -m pip install . -vv


### PR DESCRIPTION
rattler-build trips on our build string (which I'm hitting because I'm working on pinning stuff). I see 2 ways around this: convert to an underscore, which isn't optimal because it is a delimiter elsewhere in the build string, or removing the "." and cramming the minor version in.

This is pretty esoteric, so I don't think it'll matter much either way, but we should do something about this, or else we won't be able to include this package in pins (for example, work in https://github.com/rapidsai/cuml/pull/7015)

```
Error:   × Parsing: failed to parse match spec: the build string '12.9_py313_250626*' is not valid, it can only contain alphanumeric characters and underscores
     ╭─[402:7]
 401 │     - pynndescent 0.5.13 pyhd8ed1ab_1
 402 │     - pynvjitlink 0.7.0 12.9_py313_250626*
     ·       ──────────────────┬─────────────────
     ·                         ╰── error parsing `pynvjitlink 0.7.0 12.9_py313_250626*` as a match spec
 403 │     - pynvml 12.0.0 pyhd8ed1ab_0
```
