### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/pynvjitlink/recipe.yaml
+++ b/conda/recipes/pynvjitlink/recipe.yaml
@@ -52,7 +52,7 @@ requirements:
     - libnvjitlink-static
     - python =${{ py_version }}
     - pip
-    - rapids-build-backend >=0.3.0,<0.4.0dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - scikit-build-core >=0.10.0
   run:
     - ${{ pin_compatible("cuda-version", lower_bound="x", upper_bound="x.x") }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -43,7 +43,7 @@ dependencies:
     common:
       - output_types: [requirements, pyproject]
         packages:
-          - rapids-build-backend >=0.3.0,<0.4.0dev0
+          - rapids-build-backend >=0.4.0,<0.5.0.dev0
           - scikit-build-core[pyproject]>=0.10.0
   checks:
     common:


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
